### PR TITLE
Add GetNearestGroups query

### DIFF
--- a/services/GroupMaker/.config/dotnet-tools.json
+++ b/services/GroupMaker/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.27.2",
+      "version": "0.27.3",
       "commands": [
         "dotnet-csharpier"
       ]


### PR DESCRIPTION
closes #29 

Orders the groups by the total distance the user has to walk: this includes the distance to walk from the user's start location to the group's start location AND the group's end location to the user's end location. This allows for pagination later on, which is essential.